### PR TITLE
actually output json instead of pprint python dicts

### DIFF
--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -21,6 +21,7 @@ import tempfile
 import logging
 import argparse
 import pprint
+import json
 
 from libvirtnbdbackup import argopt
 from libvirtnbdbackup import __version__
@@ -40,6 +41,7 @@ from libvirtnbdbackup.sparsestream import exceptions
 def dump(args, stream, dataFiles):
     """Dump stream contents to json output"""
     logging.info("Dumping saveset meta information")
+    entries = []
     for dataFile in dataFiles:
         if args.disk is not None and not os.path.basename(dataFile).startswith(
             args.disk
@@ -53,12 +55,14 @@ def dump(args, stream, dataFiles):
         meta = getHeader(sourceFile, stream)
 
         if not meta:
-            return False
+            continue
 
-        pprint.pprint(meta)
+        entries.append(meta)
 
         if lib.isCompressed(meta):
             logging.info("Compressed stream found: [%s].", meta["compressionMethod"])
+
+    print(json.dumps(entries, indent=4))
 
     return True
 


### PR DESCRIPTION
Previously the `dump` metadata output for a backupset was not actually JSON but rather just `pprint` output which can't be loaded/parsed as json.
Additionally each backup within a backup set was `pprint`'ed individually and the output was not even a proper list/array.

This PR fixes all of the above by first collecting all metadata entries and then properly serializing them to JSON using `json.dumps()`.

Before:
```
{'checkpointName': 'virtnbdbackup.0',                                                                                                                         
 'compressed': False,                                                                                                                                         
 'compressionMethod': 'lz4',                                                                                                                                  
 'dataSize': 2223972352,
 'date': '2022-09-21T17:04:50.212713',
 'diskFormat': 'qcow2',
 'diskName': 'sda',
 'incremental': False,
 'parentCheckpoint': False,
 'streamVersion': 2,
 'virtualSize': 161061273600}
```

After:
```
[
    {
        "virtualSize": 161061273600,
        "dataSize": 2223972352,
        "date": "2022-09-21T17:04:50.212713",
        "diskName": "sda",
        "diskFormat": "qcow2",
        "checkpointName": "virtnbdbackup.0",
        "compressed": false,
        "compressionMethod": "lz4",
        "parentCheckpoint": false,
        "incremental": false,
        "streamVersion": 2
    }
]
```