### PR TITLE
Fix #152 Restore fails if target directory exists

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,10 @@ Version 1.9.50
  * Check if specified ip address in `--nbd-ip` parameter is an
  ipv6 address and if so, use ipv6 ip notation for NBD client
  connection (#150)
+ * Fix NBD connection timeout: current implementation only waited
+ until NBD server on socket was reachable. Now it also attempts to
+ retry connection for remote TCP NBD servers (#150)
+ * Fix exception in ssh client during raise
 
 Version 1.9.49
 ---------

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,10 @@
 Version 1.9.50
 ---------
- * Add install openssh-client to docker image required for remote backup
+ * Add openssh-client to docker image required for remote backup
  functionality (#151)
+ * Check if specified ip address in `--nbd-ip` parameter is an
+ ipv6 address and if so, use ipv6 ip notation for NBD client
+ connection (#150)
 
 Version 1.9.49
 ---------

--- a/libvirtnbdbackup/common.py
+++ b/libvirtnbdbackup/common.py
@@ -184,7 +184,7 @@ def copy(args: Namespace, source: str, target: str) -> None:
     """Copy file, handle exceptions"""
     try:
         if args.sshClient:
-            args.sshClient.copy(source, target)
+            args.sshClient.sftp.put(source, target)
         else:
             shutil.copyfile(source, target)
     except OSError as e:

--- a/libvirtnbdbackup/nbdcli/client.py
+++ b/libvirtnbdbackup/nbdcli/client.py
@@ -140,8 +140,16 @@ class client:
             if self.cType.backupSocket and not os.path.exists(self.cType.backupSocket):
                 log.info("Waiting for NBD Server, Retry: %s", retry)
                 retry = retry + 1
+                continue
 
-            connection = self._connect()
+            try:
+                connection = self._connect()
+            except exceptions.NbdConnectionError as e:
+                self.nbd = nbd.NBD()
+                log.info("Waiting for NBD Server, Retry: %s [%s]", retry, e)
+                retry = retry + 1
+                continue
+
             if connection:
                 log.info("Connection to NBD backend succeeded.")
                 self.connection = connection

--- a/libvirtnbdbackup/nbdcli/client.py
+++ b/libvirtnbdbackup/nbdcli/client.py
@@ -16,6 +16,7 @@
 """
 import os
 import logging
+import ipaddress
 from time import sleep
 from dataclasses import dataclass
 import nbd
@@ -56,6 +57,14 @@ class TCP(nbdConn):
     def __post_init__(self):
         if self.tls:
             self.uri_prefix = "nbds://"
+
+        try:
+            ip = ipaddress.ip_address(self.hostname)
+            if ip.version == 6:
+                self.hostname = f"[{self.hostname}]"
+        except ValueError:
+            pass
+
         self.uri = f"{self.uri_prefix}{self.hostname}:{self.port}/{self.exportName}"
 
 

--- a/libvirtnbdbackup/nbdcli/client.py
+++ b/libvirtnbdbackup/nbdcli/client.py
@@ -150,13 +150,9 @@ class client:
                 retry = retry + 1
                 continue
 
-            if connection:
-                log.info("Connection to NBD backend succeeded.")
-                self.connection = connection
-                return self
-
-            log.info("Waiting for NBD Server, Retry: %s", retry)
-            retry = retry + 1
+            log.info("Connection to NBD backend succeeded.")
+            self.connection = connection
+            return self
 
     def disconnect(self) -> None:
         """Close nbd connection handle"""

--- a/libvirtnbdbackup/ssh/client.py
+++ b/libvirtnbdbackup/ssh/client.py
@@ -130,6 +130,7 @@ class client:
         pidOut: str
         log.debug("Executing remote command: [%s]", cmd)
         ret, err, out = self._execute(cmd)
+        logerr = ""
         if ret != 0:
             log.error(
                 "Executing command failed, return code: [%s] stderr: [%s], stdout: [%s]",
@@ -138,7 +139,7 @@ class client:
                 out,
             )
             if logFile:
-                log.debug("Attempting to catch errors from logfile")
+                log.debug("Attempting to catch errors from logfile: [%s]", logFile)
                 _, _, logerr = self._execute(f"cat {logFile}")
             raise exceptions.sshError(
                 f"Error during remote command: [{cmd}]: [{err}] [{logerr}]"

--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -581,7 +581,11 @@ def main() -> None:
         help="Directory including a backup set",
     )
     opt.add_argument(
-        "-o", "--output", required=True, type=str, help="Restore target directory, creates the directory if it doesn't exist.",
+        "-o",
+        "--output",
+        required=True,
+        type=str,
+        help="Restore target directory, creates the directory if it doesn't exist.",
     )
     opt.add_argument(
         "-u",

--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -24,6 +24,7 @@ import logging
 import argparse
 import pprint
 import json
+import pathlib
 from argparse import Namespace
 from typing import List, Union, Dict
 from libvirtnbdbackup import argopt
@@ -515,7 +516,7 @@ def restore(args: Namespace, ConfigFile: str, virtClient: virt.client) -> bytes:
 def restoreConfig(args: Namespace, vmConfig: str, adjustedConfig: bytes) -> None:
     """Restore either original or adjusted vm configuration
     to new directory"""
-    targetFile = f"{args.output}/{os.path.basename(vmConfig)}"
+    targetFile = str(pathlib.Path(args.output).joinpath(os.path.basename(vmConfig)))
     if args.adjust_config is True:
         if args.sshClient:
             with tempfile.NamedTemporaryFile(delete=True) as fh:
@@ -580,7 +581,7 @@ def main() -> None:
         help="Directory including a backup set",
     )
     opt.add_argument(
-        "-o", "--output", required=True, type=str, help="Restore target directory"
+        "-o", "--output", required=True, type=str, help="Restore target directory, creates the directory if it doesn't exist.",
     )
     opt.add_argument(
         "-u",
@@ -716,7 +717,8 @@ def main() -> None:
             if not args.sshClient:
                 logging.error("Remote restore detected but ssh session setup failed")
                 sys.exit(1)
-            args.sshClient.sftp.mkdir(args.output)
+            if not args.sshClient.exists(args.output):
+                args.sshClient.sftp.mkdir(args.output)
         else:
             output.target.Directory().create(args.output)
 

--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -24,7 +24,6 @@ import logging
 import argparse
 import pprint
 import json
-import pathlib
 from argparse import Namespace
 from typing import List, Union, Dict
 from libvirtnbdbackup import argopt
@@ -516,7 +515,7 @@ def restore(args: Namespace, ConfigFile: str, virtClient: virt.client) -> bytes:
 def restoreConfig(args: Namespace, vmConfig: str, adjustedConfig: bytes) -> None:
     """Restore either original or adjusted vm configuration
     to new directory"""
-    targetFile = str(pathlib.Path(args.output).joinpath(os.path.basename(vmConfig)))
+    targetFile = str(os.path.join(args.output, os.path.basename(vmConfig)))
     if args.adjust_config is True:
         if args.sshClient:
             with tempfile.NamedTemporaryFile(delete=True) as fh:


### PR DESCRIPTION
This PR addresses the issue where the restore fails if the target directory exists before the restore is started.

The parameter help description has been amended as well.

I also encountered an issue when it copied the XML file over to the server. Failed with the error:
```bash
[2023-12-10 18:37:32] WARNING lib common - copy [MainThread]:  Failed to copy [/tmp/tmpfz5__lfb] to [/opt/vm-disks/vm01//vmconfig.virtnbdbackup.54.xml]: [[Errno 2] No such file or directory: '/opt/vm-disks/vm01//vmconfig.virtnbdbackup.54.xml']
```

I used `pathlib` to join the paths so that there would be no difference between `-o` output parameter paths `/opt/vm-disks/vm01` and `/opt/vm-disks/vm01/` when joining paths.

I also changed the copy method to SFTP as SSH kept failing the copy.