### PR TITLE
Fix #152 Restore fails if target directory exists

### DIFF
--- a/libvirtnbdbackup/common.py
+++ b/libvirtnbdbackup/common.py
@@ -184,7 +184,7 @@ def copy(args: Namespace, source: str, target: str) -> None:
     """Copy file, handle exceptions"""
     try:
         if args.sshClient:
-            args.sshClient.copy(source, target)
+            args.sshClient.sftp.put(source, target)
         else:
             shutil.copyfile(source, target)
     except OSError as e:

--- a/libvirtnbdbackup/common.py
+++ b/libvirtnbdbackup/common.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 import colorlog
 
 from libvirtnbdbackup import ssh
+from libvirtnbdbackup.ssh.client import Mode
 from libvirtnbdbackup.ssh.exceptions import sshError
 from libvirtnbdbackup import output
 from libvirtnbdbackup.logcount import logCount
@@ -72,6 +73,8 @@ def setLogLevel(verbose: bool) -> int:
 def sshSession(args: Namespace, remoteHost: str) -> Union[ssh.client, None]:
     """Use ssh to copy remote files"""
     try:
+        if args.action == "restore":
+            return ssh.client(remoteHost, args.ssh_user, mode=Mode.UPLOAD)
         return ssh.client(remoteHost, args.ssh_user)
     except sshError as err:
         log.warning("Failed to setup SSH connection: [%s]", err)
@@ -184,7 +187,7 @@ def copy(args: Namespace, source: str, target: str) -> None:
     """Copy file, handle exceptions"""
     try:
         if args.sshClient:
-            args.sshClient.sftp.put(source, target)
+            args.sshClient.copy(source, target)
         else:
             shutil.copyfile(source, target)
     except OSError as e:

--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -515,7 +515,7 @@ def restore(args: Namespace, ConfigFile: str, virtClient: virt.client) -> bytes:
 def restoreConfig(args: Namespace, vmConfig: str, adjustedConfig: bytes) -> None:
     """Restore either original or adjusted vm configuration
     to new directory"""
-    targetFile = f"{args.output}/{os.path.basename(vmConfig)}"
+    targetFile = str(os.path.join(args.output, os.path.basename(vmConfig)))
     if args.adjust_config is True:
         if args.sshClient:
             with tempfile.NamedTemporaryFile(delete=True) as fh:
@@ -580,7 +580,11 @@ def main() -> None:
         help="Directory including a backup set",
     )
     opt.add_argument(
-        "-o", "--output", required=True, type=str, help="Restore target directory"
+        "-o",
+        "--output",
+        required=True,
+        type=str,
+        help="Restore target directory, creates the directory if it doesn't exist.",
     )
     opt.add_argument(
         "-u",
@@ -716,7 +720,8 @@ def main() -> None:
             if not args.sshClient:
                 logging.error("Remote restore detected but ssh session setup failed")
                 sys.exit(1)
-            args.sshClient.sftp.mkdir(args.output)
+            if not args.sshClient.exists(args.output):
+                args.sshClient.sftp.mkdir(args.output)
         else:
             output.target.Directory().create(args.output)
 


### PR DESCRIPTION
This PR addresses issue #152 where the restore fails if the target directory exists before the restore is started.

The parameter help description has been amended as well.

I also encountered an issue when it copied the XML file over to the server. Failed with the error:
```bash
[2023-12-10 18:37:32] WARNING lib common - copy [MainThread]:  Failed to copy [/tmp/tmpfz5__lfb] to [/opt/vm-disks/vm01//vmconfig.virtnbdbackup.54.xml]: [[Errno 2] No such file or directory: '/opt/vm-disks/vm01//vmconfig.virtnbdbackup.54.xml']
```

I used `os.path.join` to join the paths so that there would be no difference between `-o` output parameter paths `/opt/vm-disks/vm01` and `/opt/vm-disks/vm01/` when joining paths.

I also changed the copy method to SFTP as SSH kept failing the copy.