### PR TITLE
handle lost CBT case

### DIFF
--- a/libvirtnbdbackup/extenthandler/extenthandler.py
+++ b/libvirtnbdbackup/extenthandler/extenthandler.py
@@ -203,54 +203,7 @@ class ExtentHandler:
             e for e in extents if e.context == self._metaContext and e.data
         ]
 
-        selected_extents = []
         totalLength: int = 0
-        base_index = 0
-        base_count = len(base_extents)
-
-        for backup in backup_extents:
-            backup_end = backup.offset + backup.length
-            while (
-                base_index < base_count
-                and base_extents[base_index].offset + base_extents[base_index].length
-                <= backup.offset
-            ):
-                base_index += 1
-
-            # Process relevant base extents
-            current_index = base_index
-            while current_index < base_count:
-                base = base_extents[current_index]
-
-                # Stop if the base extent starts after the backup extent ends
-                if base.offset > backup_end:
-                    break
-
-                base_end = base.offset + base.length
-                log.debug(
-                    "add base0 %d %d %d %d",
-                    backup.offset,
-                    base.offset,
-                    base_end,
-                    backup_end,
-                )
-
-                ext = Extent(base.context, base.data, base.offset, base.length)
-                ext.offset = max(base.offset, backup.offset)
-                ext_end = min(base_end, backup_end)
-                ext.length = max(0, ext_end - ext.offset)
-                if ext.length and ext.data:
-                    log.debug(
-                        "-> extent %d %d %d",
-                        ext.offset,
-                        ext.offset + ext.length,
-                        ext.length,
-                    )
-                    selected_extents.append(ext)
-                    totalLength += ext.length
-
-                current_index += 1
-
         result = []
         i = 0  # index for base_extents
         j = 0  # index for backup_extents
@@ -279,23 +232,13 @@ class ExtentHandler:
                 offset=offset,
                 length=end - offset,
             ))
+            totalLength += end - offset
 
             # advance
             if end == base.offset + base.length:
                 i += 1
             if end == backup.offset + backup.length:
                 j += 1
-
-        if len(selected_extents) != len(result):
-            sys.exit(-1)
-
-        i = 0  # index for base_extents
-        while i < min(len(selected_extents), len(result)):
-            old = selected_extents[i]
-            new = result[i]
-            if old.length != new.length or old.offset != new.offset:
-                sys.exit(-1)
-            i += 1
 
         if totalLength > 0:
             log.info(


### PR DESCRIPTION
It is legal that CBT inside QEMU could be lost f.e. once the power on the node would be lost or QEMU will be crashed. Dirty bitmaps are stored inside QCOW2 as auto-clear feature and are removed on every start when the image is unclean. This is done as CBTs are kept in the memory and are written only during normal QEMU shutdown process.

This situation should be handled by the backup software. Backup chains should not be broken and the only normal way to handle this would be to make full backup and store it inside incremental chain. Letting resolving this by the end-user would be not friendly to the end-user.

The condition is rare and we should just create full backup in this case. Handle this respectively in the code.

Note: this requires change in the extent handling. As CBT is not available, BLOCK_STATUS requests offset should be moved over libvirt.CONTEXT_BASE_ALLOCATION namespace processing.