### PR TITLE
handle lost CBT case

### DIFF
--- a/libvirtnbdbackup/backup/check.py
+++ b/libvirtnbdbackup/backup/check.py
@@ -93,7 +93,6 @@ def vmstate(args, virtClient: virt.client, domObj: virDomain) -> None:
         log.warning("Domain is offline, resetting backup options.")
         args.level = "copy"
         log.warning("New Backup level: [%s].", args.level)
-        args.offline = True
 
     if args.offline is True and args.startonly is True:
         raise exceptions.BackupException(

--- a/libvirtnbdbackup/backup/target.py
+++ b/libvirtnbdbackup/backup/target.py
@@ -40,14 +40,14 @@ def Set(args: Namespace, disk: DomainDisk, ext: str = "data"):
     """Set Target file name to write data to, used for both data files
     and qemu disk info"""
     targetFile: str = ""
-    if args.level in ("full", "copy"):
-        level = args.level
+    level = args.level_filename
+    if level in ("full", "copy"):
         if disk.format == "raw":
             level = "copy"
         targetFile = f"{args.output}/{disk.target}.{level}.{ext}"
-    elif args.level in ("inc", "diff"):
+    elif level in ("inc", "diff"):
         cptName = getIdent(args)
-        targetFile = f"{args.output}/{disk.target}.{args.level}.{cptName}.{ext}"
+        targetFile = f"{args.output}/{disk.target}.{level}.{cptName}.{ext}"
 
     targetFilePartial = f"{targetFile}.partial"
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -27,9 +27,12 @@ fstest.tests: $(bats)
 nosparsedetect.tests: $(bats)
 	$(call clean)
 	export TEST=nosparsedetect ; ./bats-core/bin/bats nosparsedetect.bats
+cbtmiss.tests: $(bats)
+	$(call clean)
+	export TEST=cbtmiss ; ./bats-core/bin/bats cbtmiss.bats
 
 
-all: | $(bats) vm1.tests vm2.tests vm3.tests vm4.tests fstrim.tests nosparsedetect.tests fstrimsmall.tests fstest.tests
+all: | $(bats) vm1.tests vm2.tests vm3.tests vm4.tests fstrim.tests nosparsedetect.tests fstrimsmall.tests fstest.tests cbtmiss.tests
 
 clean:
 	$(call clean)

--- a/t/cbtmiss.bats
+++ b/t/cbtmiss.bats
@@ -1,0 +1,154 @@
+if [ -z "$TEST" ]; then
+    echo ""
+    echo "Missing required test env" >&2
+    echo "export TEST=<dir> to run specified tests" >&2
+    echo ""
+    exit
+fi
+
+if [ -e /root/agent ]; then
+    source /root/agent > /dev/null
+fi
+
+if [ -z "$TMPDIR" ]; then
+    export TMPDIR=$(mktemp -d)
+    chmod go+rwx $TMPDIR
+fi
+
+load $TEST/config.bash
+load agent-exec.sh
+
+
+setup() {
+ aa-teardown >/dev/null || true
+}
+
+@test "Setup / download vm image ${IMG_URL} to ${TMPDIR}/${VM_IMAGE}" {
+    if [ ! -e ${TMPDIR}/${VM_IMAGE} ]; then
+        curl -Ls ${IMG_URL} -o ${TMPDIR}/${VM_IMAGE}
+    fi
+}
+
+@test "Setup: Define and start test VM ${VM}" {
+    virsh destroy ${VM} || true
+    echo "output = ${output}"
+    virsh undefine ${VM} --remove-all-storage --checkpoints-metadata || true
+    echo "output = ${output}"
+    cp ${VM}/${VM}.xml ${TMPDIR}/
+    sed -i "s|__TMPDIR__|${TMPDIR}|g" ${TMPDIR}/${VM}.xml
+    run virsh define ${TMPDIR}/${VM}.xml
+    echo "output = ${output}"
+    run virsh start ${VM}
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+    echo "output = ${output}"
+}
+@test "Wait for VM to be reachable via guest agent" {
+    run wait_for_agent $VM
+}
+@test "Backup: create full backup" {
+    run ../virtnbdbackup -d $VM -l full -o ${TMPDIR}/cbtmiss
+    [[ "${output}" =~  "Saved qcow image config" ]]
+    [ "$status" -eq 0 ]
+}
+@test "Create data in VM 1" {
+    run execute_qemu_command $VM "cp" '["-a", "/etc", "/incdata"]'
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+    run execute_qemu_command $VM sync
+    [ "$status" -eq 0 ]
+}
+@test "Stop VM and remove CBT" {
+    run virsh destroy ${VM}
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+    run qemu-img info ${TMPDIR}/cbtmiss.qcow2
+    echo "output = ${output}"
+    run qemu-img bitmap ${TMPDIR}/cbtmiss.qcow2 --remove virtnbdbackup.0
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+}
+@test "Start VM again" {
+    run virsh start ${VM}
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+    echo "output = ${output}"
+    run wait_for_agent $VM
+}
+@test "Backup: create incremental backup" {
+    run ../virtnbdbackup -d $VM -l inc -o ${TMPDIR}/cbtmiss
+    [[ "${output}" =~  "Saved qcow image config" ]]
+    [ "$status" -eq 0 ]
+}
+@test "Create data in VM 2" {
+    run execute_qemu_command $VM "cp" '["-a", "/etc", "/incdata2"]'
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+    run execute_qemu_command $VM sync
+    [ "$status" -eq 0 ]
+}
+@test "Backup: create one more incremental backup" {
+    run ../virtnbdbackup -d $VM -l inc -o ${TMPDIR}/cbtmiss
+    [[ "${output}" =~  "Saved qcow image config" ]]
+    [ "$status" -eq 0 ]
+}
+@test "Create data in VM 3" {
+    run execute_qemu_command $VM "cp" '["-a", "/etc", "/incdata3"]'
+    [ "$status" -eq 0 ]
+    run execute_qemu_command $VM sync
+    [ "$status" -eq 0 ]
+}
+@test "Stop VM and remove CBT 2" {
+    run virsh destroy ${VM}
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+    run qemu-img info ${TMPDIR}/cbtmiss.qcow2
+    echo "output = ${output}"
+    run qemu-img bitmap ${TMPDIR}/cbtmiss.qcow2 --remove virtnbdbackup.2
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+}
+@test "Backup: create inc backup on offline VM" {
+    run ../virtnbdbackup -d $VM -l inc -S -o ${TMPDIR}/cbtmiss
+    [[ "${output}" =~  "Saved qcow image config" ]]
+    [ "$status" -eq 0 ]
+}
+@test "Restore: restore vm with new name" {
+    run ../virtnbdrestore -cD --name restored -i ${TMPDIR}/cbtmiss -o ${TMPDIR}/restore
+    echo "output = ${output}"
+    [ "$status" -eq 0 ]
+}
+@test "Verify image contents" {
+    run virt-ls -a ${TMPDIR}/restore/cbtmiss.qcow2 /
+    [[ "${output}" =~  "incdata" ]]
+    [ "$status" -eq 0 ]
+
+    run virt-ls -a ${TMPDIR}/restore/cbtmiss.qcow2 /incdata
+    [[ "${output}" =~  "sudoers" ]]
+    [ "$status" -eq 0 ]
+
+    run virt-cat -a ${TMPDIR}/restore/cbtmiss.qcow2 /incdata/sudoers
+    [[ "${output}" =~  "Uncomment" ]]
+    [ "$status" -eq 0 ]
+
+    run virt-ls -a ${TMPDIR}/restore/cbtmiss.qcow2 /incdata2
+    [[ "${output}" =~  "sudoers" ]]
+    [ "$status" -eq 0 ]
+
+    run virt-ls -a ${TMPDIR}/restore/cbtmiss.qcow2 /incdata3
+    [[ "${output}" =~  "sudoers" ]]
+    [ "$status" -eq 0 ]
+}
+@test "Start restored VM" {
+    run virsh start restored
+    [ "$status" -eq 0 ]
+}
+@test "Verify restored VM boots" {
+    run wait_for_agent restored
+    [ "$status" -eq 0 ]
+}
+@test "Check filesystem consistency after boot" {
+    run execute_qemu_command restored btrfs '["device","stats","-c", "/"]'
+    [ "$status" -eq 0 ]
+    echo "output = ${output}"
+}

--- a/t/cbtmiss/README.txt
+++ b/t/cbtmiss/README.txt
@@ -1,0 +1,5 @@
+This test uses the arch Linux cloud image to create multiple backups with
+different actions in between.
+
+This testcase is used to check that even with the missed CBT we can do
+chained backups with the replacement of one increment to full backup.

--- a/t/cbtmiss/cbtmiss.xml
+++ b/t/cbtmiss/cbtmiss.xml
@@ -1,0 +1,184 @@
+<domain type='kvm' id='4' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>cbtmiss</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://redhat.com/rhel/8.0"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit='KiB'>2048000</memory>
+  <currentMemory unit='KiB'>2048000</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='x86_64' machine='pc-q35-2.10'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+  </features>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' discard="unmap"/>
+      <source file='__TMPDIR__/cbtmiss.qcow2' index='2'/>
+      <backingStore/>
+      <target dev='sda' bus='sata'/>
+      <alias name='sata0-0-0'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <alias name='usb'/>
+      <address type='pci' domain='0x0000' bus='0x02' slot='0x00' function='0x0'/>
+    </controller>
+    <controller type='sata' index='0'>
+      <alias name='ide'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pcie-root'>
+      <alias name='pcie.0'/>
+    </controller>
+    <controller type='pci' index='1' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='1' port='0x10'/>
+      <alias name='pci.1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='pci' index='2' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='2' port='0x11'/>
+      <alias name='pci.2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x1'/>
+    </controller>
+    <controller type='pci' index='3' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='3' port='0x12'/>
+      <alias name='pci.3'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x2'/>
+    </controller>
+    <controller type='pci' index='4' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='4' port='0x13'/>
+      <alias name='pci.4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x3'/>
+    </controller>
+    <controller type='pci' index='5' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='5' port='0x14'/>
+      <alias name='pci.5'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x4'/>
+    </controller>
+    <controller type='pci' index='6' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='6' port='0x15'/>
+      <alias name='pci.6'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x5'/>
+    </controller>
+    <controller type='pci' index='7' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='7' port='0x16'/>
+      <alias name='pci.7'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x6'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
+    </controller>
+    <controller type='scsi' index='0' model='virtio-scsi'>
+      <alias name='scsi0'/>
+      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:94:ff:4f'/>
+      <source network='default' portid='99e9e122-49c8-40d6-bedd-127efc707d93' bridge='virbr0'/>
+      <target dev='vnet0'/>
+      <model type='virtio'/>
+      <alias name='net0'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <source path='/dev/pts/0'/>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/0'>
+      <source path='/dev/pts/0'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <channel type='unix'>
+      <source mode='bind' path='/tmp/org.qemu.guest_agent.0'/>
+      <target type='virtio' name='org.qemu.guest_agent.0' state='connected'/>
+      <alias name='channel0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0' state='disconnected'/>
+      <alias name='channel1'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <alias name='input0'/>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'>
+      <alias name='input1'/>
+    </input>
+    <input type='keyboard' bus='ps2'>
+      <alias name='input2'/>
+    </input>
+    <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich9'>
+      <alias name='sound0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1b' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <alias name='video0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir0'/>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir1'/>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <alias name='rng0'/>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </rng>
+  </devices>
+  <seclabel type='dynamic' model='dac' relabel='yes'>
+    <label>+107:+107</label>
+    <imagelabel>+107:+107</imagelabel>
+  </seclabel>
+  <qemu:capabilities>
+    <qemu:add capability='incremental-backup'/>
+  </qemu:capabilities>
+</domain>

--- a/t/cbtmiss/config.bash
+++ b/t/cbtmiss/config.bash
@@ -1,0 +1,3 @@
+VM="cbtmiss"
+VM_IMAGE="cbtmiss.qcow2"
+IMG_URL="https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-basic.qcow2"

--- a/t/fstrim.bats
+++ b/t/fstrim.bats
@@ -20,7 +20,7 @@ load agent-exec.sh
 
 
 setup() {
- aa-teardown >/dev/null || true
+	echo aa
 }
 
 @test "Setup / download vm image ${IMG_URL} to ${TMPDIR}/${VM_IMAGE}" {


### PR DESCRIPTION
It is legal that CBT inside QEMU could be lost f.e. once the power on the node would be lost or QEMU will be crashed. Dirty bitmaps are stored inside QCOW2 as auto-clear feature and are removed on every start when the image is unclean. This is done as CBTs are kept in the memory and are written only during normal QEMU shutdown process.

This situation should be handled by the backup software. Backup chains should not be broken and the only normal way to handle this would be to make full backup and store it inside incremental chain. Letting resolving this by the end-user would be not friendly to the end-user.

The condition is rare and we should just create full backup in this case. Handle this respectively in the code.

This change is a continuation of the discussion inside pull request #258 implemented in the more straightforward manner.