### PR TITLE
feat: add --ssh-private-key arg for custom SSH key authentication

### DIFF
--- a/libvirtnbdbackup/argopt.py
+++ b/libvirtnbdbackup/argopt.py
@@ -66,6 +66,16 @@ def addRemoteArgs(opt: _ArgumentGroup) -> None:
         ),
     )
     opt.add_argument(
+        "--ssh-private-key",
+        default=None,
+        required=False,
+        type=str,
+        help=(
+            "Path to private key file for SSH authentication "
+            "(equivalent to ssh -i). (default: %(default)s)"
+        ),
+    )
+    opt.add_argument(
         "--password",
         default=None,
         required=False,

--- a/libvirtnbdbackup/common.py
+++ b/libvirtnbdbackup/common.py
@@ -90,7 +90,8 @@ def sshSession(
 ) -> Union[ssh.client, None]:
     """Use ssh to copy remote files"""
     try:
-        return ssh.client(remoteHost, args.ssh_user, args.ssh_port, mode)
+        key_filename = getattr(args, "ssh_private_key", None)
+        return ssh.client(remoteHost, args.ssh_user, args.ssh_port, mode, key_filename)
     except sshError as err:
         log.warning("Failed to setup SSH connection: [%s]", err)
 

--- a/libvirtnbdbackup/ssh/client.py
+++ b/libvirtnbdbackup/ssh/client.py
@@ -44,12 +44,18 @@ class client:
     remote copy files from hypervisor host"""
 
     def __init__(
-        self, host: str, user: str, port: int = 22, mode: Mode = Mode.DOWNLOAD
+        self,
+        host: str,
+        user: str,
+        port: int = 22,
+        mode: Mode = Mode.DOWNLOAD,
+        key_filename: Optional[str] = None,
     ):
         self.client = None
         self.host = host
         self.user = user
         self.port = port
+        self.key_filename = key_filename
         self.copy: Callable[[str, str], None] = self.copyFrom
         if mode == Mode.UPLOAD:
             self.copy = self.copyTo
@@ -67,12 +73,15 @@ class client:
             cli = SSHClient()
             cli.load_system_host_keys()
             cli.set_missing_host_key_policy(AutoAddPolicy())
-            cli.connect(
-                self.host,
-                username=self.user,
-                port=self.port,
-                timeout=5000,
-            )
+            connect_kwargs = {
+                "hostname": self.host,
+                "username": self.user,
+                "port": self.port,
+                "timeout": 5000,
+            }
+            if self.key_filename:
+                connect_kwargs["key_filename"] = self.key_filename
+            cli.connect(**connect_kwargs)
             return cli
         except AuthenticationException as e:
             raise exceptions.sshError(f"SSH key authentication failed: {e}")


### PR DESCRIPTION
## Summary
Adds `--ssh-private-key` argument (equivalent to `ssh -i`) to allow users to specify a custom private key file for SSH authentication when performing remote backups.

## Changes
- **argopt.py**: Added `--ssh-private-key` argument to the remote backup options group
- **ssh/client.py**: Modified `SSHClient.connect()` to accept `key_filename` parameter, which is passed to paramiko's `SSHClient.connect()` only when specified
- **common.py**: Updated `sshSession()` to pass `ssh_private_key` from args to the SSH client constructor

## Use case
Users with custom SSH keys stored on encrypted storage (as described in #311) can now run:
```bash
virtnbdbackup --ssh-private-key /path/to/custom/key ...```

Closes #311