### PR TITLE
feat(restore): support single disk restore to block device

### DIFF
--- a/libvirtnbdbackup/qemu/util.py
+++ b/libvirtnbdbackup/qemu/util.py
@@ -50,14 +50,15 @@ class util:
         """Check if --compress option is set and if so, use
         qemu's compress driver during data write'"""
         cmd = []
-        if args.compress is not True:
-            cmd.append(targetFile)
-            cmd.append("--format=qcow2")
-        else:
+        fmt = "raw" if args.raw_target else "qcow2"
+        if args.compress is True:
             cmd.append("--image-opts")
             cmd.append(
                 f"driver=compress,file.driver=qcow2,file.file.driver=file,file.file.filename={targetFile}"  # pylint: disable=line-too-long
             )
+        else:
+            cmd.append(targetFile)
+            cmd.append(f"--format={fmt}")
 
         return cmd
 

--- a/libvirtnbdbackup/restore/disk.py
+++ b/libvirtnbdbackup/restore/disk.py
@@ -141,7 +141,8 @@ def restore(  # pylint: disable=too-many-branches,too-many-statements,too-many-l
             backupSize = int(meta["virtualSize"])
             if targetSize < backupSize:
                 raise RestoreError(
-                    f"Raw target [{targetFile}] is not large enough for restore. BackupSize: [{backupSize}] TargetSize: [{targetSize}]"
+                    f"Raw target [{targetFile}] is not large enough for restore."
+                    f"BackupSize: [{backupSize}] TargetSize: [{targetSize}]"
                 )
 
         try:

--- a/libvirtnbdbackup/restore/disk.py
+++ b/libvirtnbdbackup/restore/disk.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import logging
+import subprocess
 from argparse import Namespace
 from libvirtnbdbackup import virt
 from libvirtnbdbackup import common as lib
@@ -48,6 +49,22 @@ def _backingstore(args: Namespace, disk: DomainDisk) -> None:
         logging.warning("Configured backing store images must be changed.")
 
 
+def _getBlockdevSize(path: str, sshClient=None) -> int:
+    cmd = ["blockdev", "--getsize64", path]
+
+    if sshClient is None:
+        result = subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return int(result.stdout.decode())
+
+    output = sshClient.run(" ".join(cmd))
+    return int(output.out)
+
+
 def restore(  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
     args: Namespace, ConfigFile: str, virtClient: virt.client
 ) -> bytes:
@@ -77,9 +94,17 @@ def restore(  # pylint: disable=too-many-branches,too-many-statements,too-many-l
                 restConfig = vmconfig.removeDisk(restConfig.decode(), disk.target)
             continue
 
-        targetFile = files.target(args, disk)
+        if args.raw_target:
+            targetFile = args.raw_target
+        else:
+            targetFile = files.target(args, disk)
 
-        if args.raw and disk.format == "raw":
+        if (
+            args.raw
+            and disk.format == "raw"
+            or args.raw_target
+            and disk.format == "raw"
+        ):
             logging.info("Restoring raw image to [%s]", targetFile)
             lib.copy(args, restoreDisk[0], targetFile)
             continue
@@ -96,10 +121,36 @@ def restore(  # pylint: disable=too-many-branches,too-many-statements,too-many-l
 
         meta = header.get(restoreDisk[cptnum], stream)
 
+        if args.raw_target:
+            targetExists = lib.exists(args, targetFile)
+            if not targetExists:
+                raise RestoreError(
+                    f"Raw target [{targetFile}] does not exists, unable to restore."
+                )
+
+            logging.info(
+                "Raw target [%s] already exists, restoring into it as-is", targetFile
+            )
+            try:
+                targetSize = _getBlockdevSize(targetFile, args.sshClient)
+            except Exception as err:
+                raise RestoreError(
+                    f"Unable to retrieve target block device size. {err}"
+                ) from err
+
+            backupSize = int(meta["virtualSize"])
+            if targetSize < backupSize:
+                raise RestoreError(
+                    f"Raw target [{targetFile}] is not large enough for restore. BackupSize: [{backupSize}] TargetSize: [{targetSize}]"
+                )
+
         try:
-            image.create(args, meta, targetFile, args.sshClient)
+            if args.output:
+                image.create(args, meta, targetFile, args.sshClient)
         except RestoreError as errmsg:
-            raise RestoreError("Creating target image failed.") from errmsg
+            raise RestoreError(
+                f"Creating target image failed. Exception {errmsg}"
+            ) from errmsg
 
         try:
             connection = server.start(args, meta["diskName"], targetFile, virtClient)

--- a/libvirtnbdbackup/restore/sequence.py
+++ b/libvirtnbdbackup/restore/sequence.py
@@ -41,14 +41,18 @@ def restore(args: Namespace, dataFiles: List[str], virtClient: virt.client) -> b
         return result
 
     diskName = meta["diskName"]
-    targetFile = os.path.join(args.output, diskName)
-    if lib.exists(args, targetFile):
-        raise RestoreError(f"Targetfile {targetFile} already exists.")
 
-    try:
-        image.create(args, meta, targetFile, args.sshClient)
-    except RestoreError as errmsg:
-        raise errmsg
+    if args.raw_target:
+        targetFile = args.raw_target
+    else:
+        targetFile = os.path.join(args.output, diskName)
+        if lib.exists(args, targetFile):
+            raise RestoreError(f"Targetfile {targetFile} already exists.")
+
+        try:
+            image.create(args, meta, targetFile, args.sshClient)
+        except RestoreError as errmsg:
+            raise errmsg
 
     connection = server.start(args, diskName, targetFile, virtClient)
 

--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -64,7 +64,9 @@ def main() -> None:
             "--sequence vdb.full.data,vdb.inc.virtnbdbackup.1.data\n"
             "   # Restore to remote system:\n"
             "\t%(prog)s -U qemu+ssh://root@remotehost/system"
-            " --ssh-user root -i /backup/ -o /remote_target"
+            " --ssh-user root -i /backup/ -o /remote_target\n"
+            "   # Restore single disk to raw device:\n"
+            "\t%(prog)s -i /backup/ -d vda --raw-target /dev/disk1"
         ),
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -86,7 +88,7 @@ def main() -> None:
         help="Directory including a backup set",
     )
     opt.add_argument(
-        "-o", "--output", required=True, type=str, help="Restore target directory"
+        "-o", "--output", required=False, type=str, help="Restore target directory"
     )
     opt.add_argument(
         "-u",
@@ -181,6 +183,12 @@ def main() -> None:
         action="store_true",
         help="Use compression driver during restore. (default: %(default)s)",
     )
+    opt.add_argument(
+        "-RT",
+        "--raw-target",
+        type=str,
+        help="Restore single disk to raw target. Requires --disk and is mutually exclusive with --output",
+    )
 
     remopt = parser.add_argument_group("Remote Restore options")
     argopt.addRemoteArgs(remopt)
@@ -202,6 +210,10 @@ def main() -> None:
     counter = logCount()  # pylint: disable=unreachable
     lib.configLogger(args, fileLog, counter)
     lib.printVersion(__version__)
+
+    if not (args.output or args.raw_target):
+        logging.error("Command must have at least one (--output, --raw-target)")
+        sys.exit(1)
 
     if not lib.exists(args, args.input):
         logging.error("Backup source [%s] does not exist.", args.input)
@@ -233,6 +245,18 @@ def main() -> None:
             sys.exit(1)
         sys.exit(0)
 
+    if args.output and args.raw_target:
+        logging.error("Cannot use --raw-target with --output")
+        sys.exit(1)
+
+    if args.raw_target and not (args.disk or args.sequence):
+        logging.error("Must provide one --disk or --sequence with --raw-target")
+        sys.exit(1)
+
+    if args.raw_target and args.compress is True:
+        logging.error("--compress cannot be used with --raw-target")
+        sys.exit(1)
+
     if args.action == "restore":
         if args.define is True:
             args.adjust_config = True
@@ -248,11 +272,12 @@ def main() -> None:
             logging.warning("Unable to connect libvirt: [%s]", e)
 
         if virtClient and virtClient.remoteHost:
-            if not args.output.startswith("/"):
-                logging.error(
-                    "Absolute target path required for restore to remote system"
-                )
-                sys.exit(1)
+            if args.output:
+                if not args.output.startswith("/"):
+                    logging.error(
+                        "Absolute target path required for restore to remote system"
+                    )
+                    sys.exit(1)
 
             args.sshClient = lib.sshSession(
                 args, virtClient.remoteHost, mode=Mode.UPLOAD
@@ -260,11 +285,13 @@ def main() -> None:
             if not args.sshClient:
                 logging.error("Remote restore detected but ssh session setup failed")
                 sys.exit(1)
-            if not args.sshClient.exists(args.output):
-                logging.info("Create target directory: [%s]", args.output)
-                args.sshClient.sftp.mkdir(args.output)
+            if args.output:
+                if not args.sshClient.exists(args.output):
+                    logging.info("Create target directory: [%s]", args.output)
+                    args.sshClient.sftp.mkdir(args.output)
         else:
-            Directory().create(args.output)
+            if args.output:
+                Directory().create(args.output)
 
         ConfigFiles = lib.getLatest(args.input, "vmconfig*.xml")
         if not ConfigFiles:
@@ -292,6 +319,10 @@ def main() -> None:
         except RestoreError as errmsg:
             logging.error("Disk restore failed: [%s]", errmsg)
             sys.exit(1)
+
+        if args.raw_target:
+            logging.info("Raw target restore complete: [%s]", args.raw_target)
+            sys.exit(0)
 
         files.restore(args, ConfigFile, virtClient)
         vmconfig.restore(args, ConfigFile, restConfig, args.config_file)

--- a/virtnbdrestore
+++ b/virtnbdrestore
@@ -187,7 +187,7 @@ def main() -> None:
         "-RT",
         "--raw-target",
         type=str,
-        help="Restore single disk to raw target. Requires --disk and is mutually exclusive with --output",
+        help="Restore single disk to raw target. Requires --disk.",
     )
 
     remopt = parser.add_argument_group("Remote Restore options")


### PR DESCRIPTION
## Summary
Adds support to restore a single disk directly to a raw file or block device using a new `--raw-target` argument. 

This is particularly useful for restoring disks that used the qcow `data_file` feature, but applies broadly to any scenario where a direct-to-device restore is needed without intermediary qemu-img conversions.

### Key Changes
* Bypasses standard output directory logic to stream the restored NBD data directly to the specified target block device or raw file
* When `--raw-target` is specified, metadata and configuration files are skipped since data is written directly to a raw target

### Safety: 
* Requires `--disk`: Rejects execution if source backup disk is not specified
* Mutually exclusive with `--output` and `--compress`
* Verifies target device is large enough before restoring, uses `blockdev --getsize64`
* Exits if both `--output` and `--raw-target` are defined

### Example
`virtnbdrestore -d vda -i /backups --raw-target /dev/disk1`

The initial remote restore test worked. I will report back after additional testing. 

Let me know your thoughts :)